### PR TITLE
chore(ci): upgrade actions/stale from v9 to v10

### DIFF
--- a/.github/workflows/stale-bot.yml
+++ b/.github/workflows/stale-bot.yml
@@ -11,7 +11,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@v10
         with:
           stale-pr-message: 'This PR is stale because it has been open 25 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
           close-pr-message: 'This PR was closed because it has been inactive for 5 days after being marked stale.'


### PR DESCRIPTION
## Summary
Bumps the `actions/stale` GitHub Action from v9 to v10 in the `stale-bot.yml` workflow. No configuration changes — all existing options are preserved as-is. This is part of a batch upgrade across all `fern-api` repos that use this action.

## Review & Testing Checklist for Human
- [ ] Confirm that [`actions/stale` v10 release notes](https://github.com/actions/stale/releases/tag/v10.0.0) don't introduce breaking changes for the options used here (`stale-pr-message`, `close-pr-message`, `days-before-issue-stale`, `days-before-issue-close`, `days-before-pr-stale`, `days-before-pr-close`, `operations-per-run`)

### Notes
- [Devin Session](https://app.devin.ai/sessions/f2a901ba4ed548ee96528facced49094)
- Requested by: @davidkonigsberg